### PR TITLE
Temporarily disables RawInput driver

### DIFF
--- a/port/src/input.c
+++ b/port/src/input.c
@@ -75,7 +75,7 @@ static s32 connectedMask = 0;
 static s32 numJoysticks = 0;
 
 static s32 useHIDAPI = 1;
-static s32 useRawInput = 1;
+static s32 useRawInput = 0;
 
 static s32 mouseEnabled = 1;
 static s32 mouseX, mouseY;


### PR DESCRIPTION
Due to a Windows Update regression: RawInput driver has a issue related to Xbox Controllers' trigger input only being detected. For safety reasons, `useRawInput` will be disabled by default until the bug is fixed on Microsoft's end.

for those who still needs it: you can head over to `pd.ini` and revert `useRawInput` back to `1`